### PR TITLE
Bugfix: API was global error handler

### DIFF
--- a/protected/modules/api/ApiModule.php
+++ b/protected/modules/api/ApiModule.php
@@ -46,11 +46,5 @@ class ApiModule extends CWebModule
 		$this->setImport(array(
 			"api.components.*"
 		));
-
-		Yii::app()->setComponents(array(
-			'errorHandler' => array(
-				'errorAction' => 'api/api/error',
-			),
-		));
 	}
 }

--- a/protected/modules/api/controllers/ApiController.php
+++ b/protected/modules/api/controllers/ApiController.php
@@ -41,6 +41,8 @@ class ApiController extends CController
 
 		// Instantiate the ApiBackend Class
 		$this->apiBackend = new ApiBackend();
+
+		Yii::app()->errorHandler->errorAction='api/api/error';
 	}
 
 	/**


### PR DESCRIPTION
The API was the global error handler, so if there is an error appearing on the vm-manager it was handeled by the API which returns a JSON answer.

This should now be fixed, because the API error handler now only applies to the API :)